### PR TITLE
Add `id` global

### DIFF
--- a/R/globalVariables.R
+++ b/R/globalVariables.R
@@ -2,7 +2,7 @@ globalVariables(c('.', 'day', 'daydat', 'flo', 'year', 'res', 'nrms_variable', '
   'fits_value', 'bt_norm', 'bt_fits', 'lnres', 'lnQ', 'value', 'taus', 'month', 'i', 'tidfit', 'trndvar',
   'rsdnl', 'mod', 'Year', 'mo', 'fake_date', 'flo.x', 'flo.y', 'nrm', 'fit', 'year_dum', 'month2',
   'yrcat', 'mocat', 'matches', 'yr', 'yrchg', 'val', 'xvar', 'one_of', 'data', 'sk_res', 'slope', 'med',
-  'is.not.finite.warning', 'rank.w.na'))
+  'is.not.finite.warning', 'rank.w.na', 'id'))
 
 #' @importFrom stats AIC approx arima.sim ave coef constrOptim fitted lm median na.omit na.pass nobs optim pchisq pnorm predict qnorm quantile resid rnorm sd var
 NULL


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

Your package does one of two things:

- It re-exports `dplyr::id()`, which has been defunct for many years and has now been removed from dplyr.

- It references a column named `id`, likely in a `mutate()` or `summarise()`, but does not note this as a global variable with `utils::globalVariables("id")`. In this case, you got lucky that dplyr exported `id()`, meaning that you did not need a global variable for `"id"`. Since we have removed `dplyr::id()`, your package will need this now.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!